### PR TITLE
device: enable orientation bridge by default

### DIFF
--- a/pmaports/device/testing/device-daylight-jagar/APKBUILD
+++ b/pmaports/device/testing/device-daylight-jagar/APKBUILD
@@ -2,7 +2,7 @@ maintainer="Denys Vitali <denys@denv.it>"
 pkgname=device-daylight-jagar
 pkgdesc="Daylight Computer DC-1"
 pkgver=1
-pkgrel=65
+pkgrel=66
 url="https://postmarketos.org"
 license="MIT"
 arch="aarch64"
@@ -219,6 +219,9 @@ package() {
 		"$pkgdir"/usr/libexec/dc1-orientation
 	install -Dm644 "$srcdir"/dc1-orientation.service \
 		"$pkgdir"/usr/lib/systemd/user/dc1-orientation.service
+	install -d "$pkgdir"/usr/lib/systemd/user/default.target.wants
+	ln -s ../dc1-orientation.service \
+		"$pkgdir"/usr/lib/systemd/user/default.target.wants/dc1-orientation.service
 
 	# The power key must not reach a sleep path, and must not blank a panel
 	# whose frontlight stays lit: logind ignores the keys, and the gschema


### PR DESCRIPTION
## Summary

Enable `dc1-orientation.service` from the vendor user-unit directory so it starts with each graphical user session. Bump the device package revision to force a rebuild.

## Hardware result

On an r65 installation the service was installed but disabled, leaving SensorProxy orientation `undefined`. `systemctl --user enable --now dc1-orientation.service` immediately produced `left-up`, applied the Mutter transform, and auto-rotation was confirmed on the panel.
